### PR TITLE
Fixed issue with deploy action, and disabled rustfmt

### DIFF
--- a/.github/workflows/deploy-gh.yaml
+++ b/.github/workflows/deploy-gh.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -39,14 +39,14 @@ jobs:
 
       - name: Build docs
         run: |
-          cargo doc --document-private-items --workspace
+          cargo doc --document-private-items --workspace --all-features
           cp -R target/doc www/dist/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           path: www/dist
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [] #[opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [] #[opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -1,10 +1,10 @@
 name: rustfmt
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
+  #push:
+  #  branches:
+  #    - main
+  #pull_request:
+  #  types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -4,8 +4,7 @@ version = "Two"
 max_width = 132
 
 struct_lit_width = 0    # default 18 (24)
-fn_call_width=100       # default 60 (80)
-array_width=132         # default 60 (80)
+array_width=130         # default 60 (80)
 #chain_width=100        # default 60 (80)
 #attr_fn_like_width=100  # default 70 (92)
 #single_line_if_else_max_width=100  # default 50 (66)


### PR DESCRIPTION
It wanted to remove most of the whitespace from trailing comments which hurts the readability of it, and there doesn't seem to be a way of configuring that, so I'll disable it for now